### PR TITLE
Download artifact from corresponding create-release-pr run

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   require-additional-reviewer:
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     # The string argument must match the release branch PR name prefix of
@@ -14,10 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: release-authors
-          path: gh-action__release-authors
       - uses: ./
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          artifacts-path: gh-action__release-authors
+          github-repository: ${{ github.repository }}
+          pull-request-head-sha: ${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ It is designed to be used with [`MetaMask/action-create-release-pr`](https://git
 
 This action is designed to be used in conjunction with [`MetaMask/action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr).
 
-To use this action, you need to make a small addition to the `action-create-release-pr` workflow, and add a new workflow to your repository.
+To use this action, you need to make a small addition to the `action-create-release-pr` workflow of your repository, and add a new workflow that uses this action:
 
 - [`.github/workflows/create-release-pr.yml`](https://github.com/MetaMask/action-require-additional-reviewer/blob/main/.github/workflows/create-release-pr.yml)
 - [`.github/workflows/require-additional-reviewer.yml`](https://github.com/MetaMask/action-require-additional-reviewer/blob/main/.github/workflows/require-additional-reviewer.yml)
-  \_ **This workflow file self-references this action with the string "`/.`". Replace that string with "`MetaMask/action-require-additional-reviewer@v1`" in your workflow.**
+  - **This workflow file self-references this action with the string "`/.`". Replace that string with "`MetaMask/action-require-additional-reviewer@v1`" in your workflow.**
 
 Once the Require Additional Reviewer workflow has run once, you can add it as a mandatory check in your repository branch protection settings.
+
+Note that, if you use this action, you **must not** rebase your release PRs before merging them back into the base branch.
+This action uses the commit hash of the base branch head to identify the workflow that created the release PR, in order to download the artifacts of that workflow.
+Merging the base branch into the release branch is fine.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,23 @@ name: 'Require Additional Reviewer'
 description: 'Require additional reviewers of automatically created Pull Requests.'
 
 inputs:
+  # required, no defaults
+  github-repository:
+    description: 'The github.repository context value for the current workflow, e.g. MetaMask/metamask-extension.'
+    required: true
+  pull-request-head-sha:
+    description: 'The head ref (SHA) of the pull request base branch.'
+    required: true
+
+  # required, but have defaults
+  artifact-name:
+    description: 'The name of the artifact containing the release PR author name.'
+    default: 'release-authors'
+    required: true
+  artifact-workflow-name:
+    description: 'The name of the workflow that writes the release author artifact.'
+    default: 'Create Release Pull Request'
+    required: true
   artifacts-path:
     description: 'The path to the directory where this action will look for its required artifacts.'
     default: 'gh-action__release-authors'
@@ -10,6 +27,15 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Download Release Author Artifact
+      shell: bash
+      run: |
+        ${{ github.action_path }}/scripts/download-artifact.sh \
+          ${{ inputs.artifacts-path }} \
+          ${{ inputs.artifact-name }} \
+          ${{ inputs.artifact-workflow-name }} \
+          ${{ inputs.pull-request-head-sha }} \
+          ${{ inputs.github-repository }}
     - name: Check for Additional Reviewers
       shell: bash
       run: |

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+# This script downloads the artifact with the specified name to the specified
+# directory, from the successful workflow run corresponding to the specified
+# workflow name, pull request base branch head commit hash, and GitHub
+# repository identifier.
+
+# The path to the directory where the artifact files will be downloaded.
+ARTIFACTS_DIR_PATH=${1}
+
+if [[ -z $ARTIFACTS_DIR_PATH ]]; then
+  echo "Error: No artifacts directory specified."
+  exit 1
+fi
+
+# The name of the artifact to download.
+ARTIFACT_NAME=${2}
+
+if [[ -z $ARTIFACT_NAME ]]; then
+  echo "Error: No artifact name specified."
+  exit 1
+fi
+
+# Inputs 3-5 are used to identify the workflow run to download artifacts from.
+
+WORKFLOW_NAME=${3}
+
+if [[ -z $WORKFLOW_NAME ]]; then
+  echo "Error: No workflow name specified."
+  exit 1
+fi
+
+PULL_REQUEST_HEAD_SHA=${4}
+
+if [[ -z $PULL_REQUEST_HEAD_SHA ]]; then
+  echo "Error: No pull request base branch HEAD ref specified."
+  exit 1
+fi
+
+GITHUB_REPOSITORY=${5}
+
+if [[ -z $GITHUB_REPOSITORY ]]; then
+  echo "Error: No GitHub repository identifier specified."
+  exit 1
+fi
+
+# We need the ID of the workflow that created the current release PR, in order
+# to download the artifacts of that workflow.
+#
+# See the end of the file for details on the response value from GitHub.
+WORKFLOW_ID=$(
+  gh api "/repos/${GITHUB_REPOSITORY}/actions/runs" |
+  jq '.workflow_runs |
+    map(select(
+      .name == "'"${WORKFLOW_NAME}"'" and
+      (.conclusion | test("^success$"; "i"))
+      .head_sha == '"${PULL_REQUEST_HEAD_SHA}"'
+    ))[0].id
+  '
+)
+
+if [[ -z $WORKFLOW_ID || "$WORKFLOW_ID" == null ]]; then
+  echo "Error: Failed to extract workflow ID."
+  exit 1
+fi
+
+# Finally, we can download the artifacts for the correct workflow run and write
+# them to the specified artifacts directory.
+mkdir -p "$ARTIFACTS_DIR_PATH" && cd "$ARTIFACTS_DIR_PATH"
+gh run download "$WORKFLOW_ID" -n "$ARTIFACT_NAME"
+
+# gh api /repos/ORG_NAME/REPO_NAME/actions/runs
+# 
+# https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
+# https://docs.github.com/en/graphql/reference/objects#workflowrun
+# https://docs.github.com/en/graphql/reference/objects#checkrun
+# https://docs.github.com/en/graphql/reference/enums#checkconclusionstate
+#
+# [
+#  {
+#    "id": 1118040733,
+#    "name": "Create Release Pull Request",
+#    "node_id": "WFR_kwLOFShwTM5Co_Kd",
+#    "head_branch": "main",
+#    "head_sha": "a71c77620588491bd7becf547c5d7bb4e70dac8b",
+#    "run_number": 9,
+#    "event": "workflow_dispatch",
+#    "status": "completed",
+#    "conclusion": "success",
+#    ...
+#  },
+#  ...
+# ]

--- a/scripts/require-additional-reviewer.sh
+++ b/scripts/require-additional-reviewer.sh
@@ -37,7 +37,7 @@ fi
 
 PR_NUMBER=$(echo "${PR_INFO}" | jq '.number')
 
-if [[ -z $PR_NUMBER ]]; then
+if [[ -z $PR_NUMBER || "${PR_NUMBER}" == null ]]; then
   echo 'Error: "gh pr view" did not return a PR number.'
   exit 1
 fi
@@ -67,9 +67,7 @@ NUM_OTHER_APPROVING_REVIEWERS=$(
   jq '.reviews |
     map(select(
       .state == "APPROVED" and (
-        .authorAssociation == "COLLABORATOR" or
-        .authorAssociation == "MEMBER" or
-        .authorAssociation == "OWNER"
+        .authorAssociation | test("^collaborator|member|owner$"; "i")
       )
     )) |
     map(.author.login) |


### PR DESCRIPTION
This PR adds our own implementation for downloading the `release-author` artifact of the `create-release-pr` run that created the given release PR.

GitHub's `action/download-artifact` only downloads artifacts within the same job, making it useless for our purposes. I didn't realize this due do lazy documentation reading on my part. Thankfully, GitHub's API made it very easy to just roll this functionality ourselves, using only Bash.