### PR TITLE
Add quotes around positional arguments to bash scripts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: 'The github.repository context value for the current workflow, e.g. MetaMask/metamask-extension.'
     required: true
   pull-request-head-sha:
-    description: 'The head ref (SHA) of the pull request base branch.'
+    description: 'The HEAD commit hash of the pull request base branch.'
     required: true
 
   # required, but have defaults
@@ -31,13 +31,13 @@ runs:
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/download-artifact.sh \
-          ${{ inputs.artifacts-path }} \
-          ${{ inputs.artifact-name }} \
-          ${{ inputs.artifact-workflow-name }} \
-          ${{ inputs.pull-request-head-sha }} \
-          ${{ inputs.github-repository }}
+          "${{ inputs.artifacts-path }}" \
+          "${{ inputs.artifact-name }}" \
+          "${{ inputs.artifact-workflow-name }}" \
+          "${{ inputs.pull-request-head-sha }}" \
+          "${{ inputs.github-repository }}"
     - name: Check for Additional Reviewers
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/require-additional-reviewer.sh \
-          ${{ inputs.artifacts-path }}
+          "${{ inputs.artifacts-path }}"


### PR DESCRIPTION
This PR adds quotes around positional arguments to bash scripts in `action.yml`, and clarifies an input description.