### PR TITLE
Fix jq syntax error

### DIFF
--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -58,7 +58,7 @@ WORKFLOW_ID=$(
     map(select(
       .name == "'"${WORKFLOW_NAME}"'" and
       (.conclusion | test("^success$"; "i")) and
-      .head_sha == '"${PULL_REQUEST_HEAD_SHA}"'
+      .head_sha == "'"${PULL_REQUEST_HEAD_SHA}"'"
     ))[0].id
   '
 )


### PR DESCRIPTION
Fixes another `jq` syntax error, this time some missing quotes.