### PR TITLE
Use pull request base branch sha value instead of target branch

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     # The string argument must match the release branch PR name prefix of
     # MetaMask/action-create-release-pr.
-    if: startsWith(github.event.pull_request.head.ref, 'release/')
+    if: startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,4 +20,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github-repository: ${{ github.repository }}
-          pull-request-head-sha: ${{ github.event.pull_request.head.sha }}
+          pull-request-base-sha: ${{ github.event.pull_request.base.sha }}

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,8 @@ inputs:
   github-repository:
     description: 'The github.repository context value for the current workflow, e.g. MetaMask/metamask-extension.'
     required: true
-  pull-request-head-sha:
-    description: 'The HEAD commit hash of the pull request base branch.'
+  pull-request-base-sha:
+    description: 'The hash of the target commit of the pull request base branch.'
     required: true
 
   # required, but have defaults
@@ -34,7 +34,7 @@ runs:
           "${{ inputs.artifacts-path }}" \
           "${{ inputs.artifact-name }}" \
           "${{ inputs.artifact-workflow-name }}" \
-          "${{ inputs.pull-request-head-sha }}" \
+          "${{ inputs.pull-request-base-sha }}" \
           "${{ inputs.github-repository }}"
     - name: Check for Additional Reviewers
       shell: bash

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -34,10 +34,10 @@ if [[ -z $WORKFLOW_NAME ]]; then
   exit 1
 fi
 
-PULL_REQUEST_HEAD_SHA=${4}
+PULL_REQUEST_BASE_SHA=${4}
 
-if [[ -z $PULL_REQUEST_HEAD_SHA ]]; then
-  echo "Error: No pull request base branch HEAD ref specified."
+if [[ -z $PULL_REQUEST_BASE_SHA ]]; then
+  echo "Error: No pull request base branch HEAD commit specified."
   exit 1
 fi
 
@@ -58,7 +58,7 @@ WORKFLOW_ID=$(
     map(select(
       .name == "'"${WORKFLOW_NAME}"'" and
       (.conclusion | test("^success$"; "i")) and
-      .head_sha == "'"${PULL_REQUEST_HEAD_SHA}"'"
+      .head_sha == "'"${PULL_REQUEST_BASE_SHA}"'"
     ))[0].id
   '
 )


### PR DESCRIPTION
The hash of the commit of the base branch HEAD is given by `github.event.pull_request.base.sha`, not `github.event.pull_request.head.sha`. This PR fixes this input.