### PR TITLE
Get the PR number as an input

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           github-repository: ${{ github.repository }}
           pull-request-base-sha: ${{ github.event.pull_request.base.sha }}
+          pull-request-number: ${{ github.event.pull_request.number }}

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   pull-request-base-sha:
     description: 'The hash of the target commit of the pull request base branch.'
     required: true
+  pull-request-number:
+    description: 'The release pull request number.'
+    required: true
 
   # required, but have defaults
   artifact-name:
@@ -40,4 +43,5 @@ runs:
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/require-additional-reviewer.sh \
-          "${{ inputs.artifacts-path }}"
+          "${{ inputs.artifacts-path }}" \
+          "${{ inputs.pull-request-number }}"

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -72,6 +72,7 @@ fi
 # them to the specified artifacts directory.
 mkdir -p "$ARTIFACTS_DIR_PATH" && cd "$ARTIFACTS_DIR_PATH"
 gh run download "$WORKFLOW_ID" -n "$ARTIFACT_NAME"
+echo "Artifact successfully downloaded!"
 
 # gh api /repos/ORG_NAME/REPO_NAME/actions/runs
 # 

--- a/scripts/require-additional-reviewer.sh
+++ b/scripts/require-additional-reviewer.sh
@@ -26,19 +26,10 @@ if [[ -z $ARTIFACTS_DIR_PATH ]]; then
   exit 1
 fi
 
-# Get the JSON data from GitHub. For the expect format of this data, see the
-# end of this file.
-PR_INFO=$(gh pr view --json number,reviews)
+PR_NUMBER=${2}
 
-if [[ -z $PR_INFO ]]; then
-  echo 'Error: "gh pr view" returned an empty value.'
-  exit 1
-fi
-
-PR_NUMBER=$(echo "${PR_INFO}" | jq '.number')
-
-if [[ -z $PR_NUMBER || "${PR_NUMBER}" == null ]]; then
-  echo 'Error: "gh pr view" did not return a PR number.'
+if [[ -z $PR_NUMBER ]]; then
+  echo "Error: No pull request number specified."
   exit 1
 fi
 
@@ -61,6 +52,15 @@ fi
 echo \
   "Identified author of release PR #${PR_NUMBER} as \"${ACTION_INITIATOR}\"." \
   "Looking for approving reviews from other organization members..."
+
+# Get the JSON data from GitHub. For the expected format of this data, see the
+# end of this file.
+PR_INFO=$(gh pr view "$PR_NUMBER" --json reviews)
+
+if [[ -z $PR_INFO ]]; then
+  echo 'Error: "gh pr view" returned an empty value.'
+  exit 1
+fi
 
 NUM_OTHER_APPROVING_REVIEWERS=$( 
   echo "${PR_INFO}" |


### PR DESCRIPTION
Previously, we grabbed the PR number from the output of `gh pr view`. This turned out to be buggy at runtime, so we now grab it from `github.event.pull_request.number` and pass it as an input instead.