### PR TITLE
Make jq operation case-insensitive

### DIFF
--- a/scripts/require-additional-reviewer.sh
+++ b/scripts/require-additional-reviewer.sh
@@ -66,9 +66,8 @@ NUM_OTHER_APPROVING_REVIEWERS=$(
   echo "${PR_INFO}" |
   jq '.reviews |
     map(select(
-      .state == "APPROVED" and (
-        .authorAssociation | test("^collaborator|member|owner$"; "i")
-      )
+      (.state | test("^approved$", "i")) and
+      (.authorAssociation | test("^collaborator|member|owner$"; "i"))
     )) |
     map(.author.login) |
     map(select(. != "'"${ACTION_INITIATOR}"'")) |

--- a/scripts/require-additional-reviewer.sh
+++ b/scripts/require-additional-reviewer.sh
@@ -66,7 +66,7 @@ NUM_OTHER_APPROVING_REVIEWERS=$(
   echo "${PR_INFO}" |
   jq '.reviews |
     map(select(
-      (.state | test("^approved$", "i")) and
+      (.state | test("^approved$"; "i")) and
       (.authorAssociation | test("^collaborator|member|owner$"; "i"))
     )) |
     map(.author.login) |


### PR DESCRIPTION
I started making `jq` tests against expected GitHub API enums case-insensitive after discovering discrepancies between their documentation and actual return values. This PR should ensure that we're not sensitive to casing for any enum we test for.