### PR TITLE
Make action robust to updating the release PR branch

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -11,13 +11,15 @@ jobs:
       pull-requests: read
     # The string argument must match the release branch PR name prefix of
     # MetaMask/action-create-release-pr.
-    if: startsWith(github.event.pull_request.head.ref, 'release/')
+    if: startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github-repository: ${{ github.repository }}
-          pull-request-head-sha: ${{ github.event.pull_request.head.sha }}
+          pull-request-base-branch: ${{ github.base_ref }}

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,8 @@ inputs:
   github-repository:
     description: 'The github.repository context value for the current workflow, e.g. MetaMask/metamask-extension.'
     required: true
-  pull-request-head-sha:
-    description: 'The HEAD commit hash of the pull request base branch.'
+  pull-request-base-branch:
+    description: 'The name of the pull request base branch.'
     required: true
 
   # required, but have defaults
@@ -34,7 +34,7 @@ runs:
           "${{ inputs.artifacts-path }}" \
           "${{ inputs.artifact-name }}" \
           "${{ inputs.artifact-workflow-name }}" \
-          "${{ inputs.pull-request-head-sha }}" \
+          "${{ inputs.pull-request-base-branch }}" \
           "${{ inputs.github-repository }}"
     - name: Check for Additional Reviewers
       shell: bash


### PR DESCRIPTION
This PR makes this action robust to merging the base branch into the PR branch, after the release PR has been created. `github.event.pull_request.base.sha` changes when the base branch is merged in, so that cannot serve as our link to the commit corresponding to the workflow that created the release PR.

By using `git rev-list` and `git merge-base`, this PR allows us to always identify the `create-release-pr` workflow commit, provided that the release PR is never rebased, which we explicitly don't support.