### PR TITLE
Remove --ancestry-path argument from git rev-list call

### DIFF
--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -56,7 +56,7 @@ fi
 # branch, if any.
 
 OLDEST_PR_BRANCH_MERGE_COMMIT=$(
-  git rev-list "$PULL_REQUEST_BASE_BRANCH"..HEAD --merges --ancestry-path --reverse |
+  git rev-list "$PULL_REQUEST_BASE_BRANCH"..HEAD --merges --reverse |
   grep -o -m 1 '\w\+'
 )
 


### PR DESCRIPTION
It's not actually what we want, in that it causes merge commits to be excluded from the output.