### PR TITLE
Use the GitHub Status API instead of action success or failure

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -10,9 +10,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    # The string argument must match the release branch PR name prefix of
-    # MetaMask/action-create-release-pr.
-    if: startsWith(github.head_ref, 'release/')
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +19,3 @@ jobs:
       - uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          github-repository: ${{ github.repository }}
-          pull-request-base-branch: ${{ github.base_ref }}
-          pull-request-number: ${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This action can be used to create workflows that require additional reviewers for programmatically created pull requests.
 It is designed to be used with [`MetaMask/action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr).
 
-`action-create-release-pr` is manually triggered by a GitHub user, but the resulting PR is authored by the GitHub Actions bot. This means that the human release author can merge their own release without third-party review. By modifying the `action-create-release-pr` workflow and using this action in a separate workflow, you can create a status check for release PRs that will only succeed if at least one organization member other than the release author has approved the PR.
+`action-create-release-pr` is manually triggered by a GitHub user, but the resulting PR is authored by the GitHub Actions bot. This means that the human release author can merge their own release without third-party review. By modifying the `action-create-release-pr` workflow and using this action in a separate workflow, a status check will be added to your PRs that you can use to ensure that at least one organization member other than the release author has approved a release PR before it can be merged.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -26,19 +26,17 @@ runs:
       id: check-branch-prefix
       shell: bash
       run: |
-        -set x
-        -set e
-        -set o pipefail
-
         PREFIX_MATCH=$(
           echo "${{ github.head_ref }}" | grep -o "^${{ inputs.release-branch-prefix }}"
         )
 
         if [[ -n $PREFIX_MATCH ]]; then
-          echo '::set-output name=is-release::true'
+          IS_RELEASE="true"
         else
-          echo '::set-output name=is-release::false'
+          IS_RELEASE="false"
         fi
+
+        echo "::set-output name=is-release::$IS_RELEASE"
 
     - name: Download Release Author Artifact
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -41,8 +41,8 @@ runs:
       run: |
         if [[ "${{ steps.check-branch-prefix.outputs.is-release }}" == "true" ]]; then
           ${{ github.action_path }}/scripts/download-artifact.sh \
-            "${{ github.base_ref }}" \
             "${{ github.repository }}" \
+            "${{ github.base_ref }}" \
             "${{ inputs.artifacts-path }}" \
             "${{ inputs.artifact-name }}" \
             "${{ inputs.artifact-workflow-name }}"

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/check-is-release.sh \
           "${{ github.head_ref }}" \
-          "{{ inputs.release-branch-prefix }}"
+          "${{ inputs.release-branch-prefix }}"
 
     - name: Download Release Author Artifact
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -2,18 +2,6 @@ name: 'Require Additional Reviewer'
 description: 'Require additional reviewers of automatically created Pull Requests.'
 
 inputs:
-  # required, no defaults
-  github-repository:
-    description: 'The github.repository context value for the current workflow, e.g. MetaMask/metamask-extension.'
-    required: true
-  pull-request-base-branch:
-    description: 'The name of the pull request base branch.'
-    required: true
-  pull-request-number:
-    description: 'The release pull request number.'
-    required: true
-
-  # required, but have defaults
   artifact-name:
     description: 'The name of the artifact containing the release PR author name.'
     default: 'release-authors'
@@ -26,22 +14,54 @@ inputs:
     description: 'The path to the directory where this action will look for its required artifacts.'
     default: 'gh-action__release-authors'
     required: true
+  release-branch-prefix:
+    description: 'The prefix of release PR branch names for this repository.'
+    default: 'release/'
+    required: true
 
 runs:
   using: 'composite'
   steps:
+    - name: Check Branch Prefix
+      id: check-branch-prefix
+      shell: bash
+      run: |
+        PREFIX_MATCH=$(
+          echo "${{ github.head_ref }}" | grep -o "^${{ inputs.release-branch-prefix }}"
+        )
+
+        if [[ -n $PREFIX_MATCH ]]; then
+          echo '::set-output name=is-release::true'
+        else
+          echo '::set-output name=is-release::false'
+        fi
+
     - name: Download Release Author Artifact
       shell: bash
       run: |
-        ${{ github.action_path }}/scripts/download-artifact.sh \
-          "${{ inputs.artifacts-path }}" \
-          "${{ inputs.artifact-name }}" \
-          "${{ inputs.artifact-workflow-name }}" \
-          "${{ inputs.pull-request-base-branch }}" \
-          "${{ inputs.github-repository }}"
+        if [[ "${{ steps.check-branch-prefix.outputs.is-release }}" == "true" ]]; then
+          ${{ github.action_path }}/scripts/download-artifact.sh \
+            "${{ github.base_ref }}" \
+            "${{ github.repository }}" \
+            "${{ inputs.artifacts-path }}" \
+            "${{ inputs.artifact-name }}" \
+            "${{ inputs.artifact-workflow-name }}"
+        fi
+
     - name: Check for Additional Reviewers
+      id: check-additional-reviewers
       shell: bash
       run: |
-        ${{ github.action_path }}/scripts/require-additional-reviewer.sh \
-          "${{ inputs.artifacts-path }}" \
-          "${{ inputs.pull-request-number }}"
+        if [[ "${{ steps.check-branch-prefix.outputs.is-release }}" == "true" ]]; then
+          ${{ github.action_path }}/scripts/check-for-additional-reviewers.sh \
+            "${{ github.event.pull_request.number }}" \
+            "${{ inputs.artifacts-path }}"
+        fi
+
+    - name: Set Commit Status
+      shell: bash
+      run: |
+        ${{ github.action_path }}/scripts/set-commit-status.sh \
+          "${{ github.repository }}" \
+          "${{ steps.check-branch-prefix.outputs.is-release }}" \
+          "${{ steps.check-additional-reviewers.outputs.num-other-approving-reviewers }}"

--- a/action.yml
+++ b/action.yml
@@ -26,17 +26,9 @@ runs:
       id: check-branch-prefix
       shell: bash
       run: |
-        PREFIX_MATCH=$(
-          echo "${{ github.head_ref }}" | grep -o "^${{ inputs.release-branch-prefix }}"
-        )
-
-        if [[ -n $PREFIX_MATCH ]]; then
-          IS_RELEASE="true"
-        else
-          IS_RELEASE="false"
-        fi
-
-        echo "::set-output name=is-release::$IS_RELEASE"
+        ${{ github.action_path }}/scripts/check-is-release.sh \
+          "${{ github.head_ref }}" \
+          "{{ inputs.release-branch-prefix }}"
 
     - name: Download Release Author Artifact
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'The prefix of release PR branch names for this repository.'
     default: 'release/'
     required: true
+  github-status-name:
+    description: 'The string that will show up as the name of the GitHub status on PRs.'
+    default: 'Additional Reviews for Releases'
+    required: true
 
 runs:
   using: 'composite'
@@ -58,5 +62,6 @@ runs:
         ${{ github.action_path }}/scripts/set-commit-status.sh \
           "${{ github.repository }}" \
           "${{ github.event.pull_request.head.sha }}" \
+          "${{ inputs.github-status-name }}" \
           "${{ steps.check-branch-prefix.outputs.is-release }}" \
           "${{ steps.check-additional-reviewers.outputs.num-other-approving-reviewers }}"

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ runs:
       id: check-branch-prefix
       shell: bash
       run: |
+        -set x
+        -set e
+        -set o pipefail
+
         PREFIX_MATCH=$(
           echo "${{ github.head_ref }}" | grep -o "^${{ inputs.release-branch-prefix }}"
         )

--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,6 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/set-commit-status.sh \
           "${{ github.repository }}" \
+          "${{ github.event.pull_request.head.sha }}" \
           "${{ steps.check-branch-prefix.outputs.is-release }}" \
           "${{ steps.check-additional-reviewers.outputs.num-other-approving-reviewers }}"

--- a/scripts/check-for-additional-reviewers.sh
+++ b/scripts/check-for-additional-reviewers.sh
@@ -19,17 +19,17 @@ set -o pipefail
 # initiator has approved the pull request, this script will exit with a non-zero
 # code.
 
-ARTIFACTS_DIR_PATH=${1}
-
-if [[ -z $ARTIFACTS_DIR_PATH ]]; then
-  echo "Error: No artifacts directory specified."
-  exit 1
-fi
-
-PR_NUMBER=${2}
+PR_NUMBER=${1}
 
 if [[ -z $PR_NUMBER ]]; then
   echo "Error: No pull request number specified."
+  exit 1
+fi
+
+ARTIFACTS_DIR_PATH=${2}
+
+if [[ -z $ARTIFACTS_DIR_PATH ]]; then
+  echo "Error: No artifacts directory specified."
   exit 1
 fi
 
@@ -74,13 +74,7 @@ NUM_OTHER_APPROVING_REVIEWERS=$(
     length'
 )
 
-if (( NUM_OTHER_APPROVING_REVIEWERS > 0 )); then
-  echo "Success! Found approving reviews from organization members."
-  exit 0
-fi
-
-echo "Failure: Did not find approving reviews from other organization members."
-exit 1
+echo ::set-output name=num-other-approving-reviewers::"$NUM_OTHER_APPROVING_REVIEWERS"
 
 # Relevant GitHub documentation:
 # https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate

--- a/scripts/check-is-release.sh
+++ b/scripts/check-is-release.sh
@@ -19,7 +19,7 @@ if [[ -z $RELEASE_BRANCH_PREFIX ]]; then
 fi
 
 PREFIX_MATCH=$(
-  echo "$HEAD_BRANCH_NAME" | grep -o "^$RELEASE_BRANCH_PREFIX"
+  echo "$HEAD_BRANCH_NAME" | grep -o "^$RELEASE_BRANCH_PREFIX" || echo ""
 )
 
 if [[ -n $PREFIX_MATCH ]]; then

--- a/scripts/check-is-release.sh
+++ b/scripts/check-is-release.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+HEAD_BRANCH_NAME=${1}
+
+if [[ -z $HEAD_BRANCH_NAME ]]; then
+  echo "Error: No head branch name specified."
+  exit 1
+fi
+
+RELEASE_BRANCH_PREFIX=${2}
+
+if [[ -z $RELEASE_BRANCH_PREFIX ]]; then
+  echo 'Error: No release branch prefix specified.'
+  exit 1
+fi
+
+PREFIX_MATCH=$(
+  echo "$HEAD_BRANCH_NAME" | grep -o "^$RELEASE_BRANCH_PREFIX"
+)
+
+if [[ -n $PREFIX_MATCH ]]; then
+  IS_RELEASE="true"
+else
+  IS_RELEASE="false"
+fi
+
+echo "::set-output name=is-release::$IS_RELEASE"

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -8,32 +8,7 @@ set -o pipefail
 # directory, from the successful workflow run corresponding to the specified
 # workflow name, pull request base branch, and GitHub repository identifier.
 
-# The path to the directory where the artifact files will be downloaded.
-ARTIFACTS_DIR_PATH=${1}
-
-if [[ -z $ARTIFACTS_DIR_PATH ]]; then
-  echo "Error: No artifacts directory specified."
-  exit 1
-fi
-
-# The name of the artifact to download.
-ARTIFACT_NAME=${2}
-
-if [[ -z $ARTIFACT_NAME ]]; then
-  echo "Error: No artifact name specified."
-  exit 1
-fi
-
-# Inputs 3-5 are used to identify the workflow run to download artifacts from.
-
-WORKFLOW_NAME=${3}
-
-if [[ -z $WORKFLOW_NAME ]]; then
-  echo "Error: No workflow name specified."
-  exit 1
-fi
-
-PULL_REQUEST_BASE_BRANCH=${4}
+PULL_REQUEST_BASE_BRANCH=${1}
 
 if [[ -z $PULL_REQUEST_BASE_BRANCH ]]; then
   echo "Error: No pull request base branch specified."
@@ -42,10 +17,35 @@ fi
 
 PULL_REQUEST_BASE_BRANCH="origin/${PULL_REQUEST_BASE_BRANCH}"
 
-GITHUB_REPOSITORY=${5}
+GITHUB_REPOSITORY=${2}
 
 if [[ -z $GITHUB_REPOSITORY ]]; then
   echo "Error: No GitHub repository identifier specified."
+  exit 1
+fi
+
+# The path to the directory where the artifact files will be downloaded.
+ARTIFACTS_DIR_PATH=${3}
+
+if [[ -z $ARTIFACTS_DIR_PATH ]]; then
+  echo "Error: No artifacts directory specified."
+  exit 1
+fi
+
+# The name of the artifact to download.
+ARTIFACT_NAME=${4}
+
+if [[ -z $ARTIFACT_NAME ]]; then
+  echo "Error: No artifact name specified."
+  exit 1
+fi
+
+# Inputs 3-5 are used to identify the workflow run to download artifacts from.
+
+WORKFLOW_NAME=${5}
+
+if [[ -z $WORKFLOW_NAME ]]; then
+  echo "Error: No workflow name specified."
   exit 1
 fi
 

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -24,6 +24,8 @@ fi
 
 PULL_REQUEST_BASE_BRANCH="origin/${PULL_REQUEST_BASE_BRANCH}"
 
+# Inputs 3-5 are used to identify the workflow run to download artifacts from.
+
 # The path to the directory where the artifact files will be downloaded.
 ARTIFACTS_DIR_PATH=${3}
 
@@ -39,8 +41,6 @@ if [[ -z $ARTIFACT_NAME ]]; then
   echo "Error: No artifact name specified."
   exit 1
 fi
-
-# Inputs 3-5 are used to identify the workflow run to download artifacts from.
 
 WORKFLOW_NAME=${5}
 

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -8,7 +8,14 @@ set -o pipefail
 # directory, from the successful workflow run corresponding to the specified
 # workflow name, pull request base branch, and GitHub repository identifier.
 
-PULL_REQUEST_BASE_BRANCH=${1}
+GITHUB_REPOSITORY=${1}
+
+if [[ -z $GITHUB_REPOSITORY ]]; then
+  echo "Error: No GitHub repository identifier specified."
+  exit 1
+fi
+
+PULL_REQUEST_BASE_BRANCH=${2}
 
 if [[ -z $PULL_REQUEST_BASE_BRANCH ]]; then
   echo "Error: No pull request base branch specified."
@@ -16,13 +23,6 @@ if [[ -z $PULL_REQUEST_BASE_BRANCH ]]; then
 fi
 
 PULL_REQUEST_BASE_BRANCH="origin/${PULL_REQUEST_BASE_BRANCH}"
-
-GITHUB_REPOSITORY=${2}
-
-if [[ -z $GITHUB_REPOSITORY ]]; then
-  echo "Error: No GitHub repository identifier specified."
-  exit 1
-fi
 
 # The path to the directory where the artifact files will be downloaded.
 ARTIFACTS_DIR_PATH=${3}

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+GITHUB_REPOSITORY=${1}
+
+if [[ -z $GITHUB_REPOSITORY ]]; then
+  echo "Error: No GitHub repository identifier specified."
+  exit 1
+fi
+
+IS_RELEASE=${2}
+
+if [[ -z $IS_RELEASE ]]; then
+  echo 'Error: No "is release" input specified.'
+  exit 1
+fi
+
+NUM_OTHER_APPROVING_REVIEWERS=${3}
+
+if [[ -z $NUM_OTHER_APPROVING_REVIEWERS ]]; then
+  echo "Error: No count of other approving reviewers specified."
+  exit 1
+fi
+
+HEAD_COMMIT_SHA=$(git show-ref -s HEAD)
+
+if [[ -z $HEAD_COMMIT_SHA ]]; then
+  echo "Error: \"git show-ref -s HEAD\" returned an empty value."
+  exit 1
+fi
+
+# Finally, compute the status for the current commit and set it via the GitHub API.
+
+COMMIT_STATUS_DESCRIPTION="Whether this PR meets the additional reviewer requirement for releases."
+COMMIT_STATUS="pending" # the default for releases
+
+if [[ "$IS_RELEASE" == "false" ]]; then
+  echo "The PR is not a release PR. Setting status to success by default."
+  COMMIT_STATUS="success"
+elif (( NUM_OTHER_APPROVING_REVIEWERS > 0 )); then
+  echo "Success! Found approving reviews from organization members."
+  COMMIT_STATUS="success"
+else
+  echo "Failure: Did not find approving reviews from other organization members."
+fi
+
+# https://cli.github.com/manual/gh_api
+# https://docs.github.com/en/rest/reference/repos#create-a-commit-status
+
+gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT_SHA}" \
+  -X "POST" \
+  -H "Accept: application/vnd.github.v3+json" \
+  -d '{
+    "context": "MetaMask/action-require-additional-reviewer",
+    "description": "'"$COMMIT_STATUS_DESCRIPTION"'",
+    "state": "'"$COMMIT_STATUS"'",
+    "target_url": "https://github.com/MetaMask/action-require-additional-reviewer"
+  }'
+
+# The action should never fail, only set a status for the release branch HEAD
+# commit.
+exit 0

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -58,9 +58,9 @@ fi
 gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT_SHA}" \
   -X "POST" \
   -H "Accept: application/vnd.github.v3+json" \
-  -f state="$COMMIT_STATUS" \
   -f context="MetaMask/action-require-additional-reviewer" \
   -f description="$COMMIT_STATUS_DESCRIPTION" \
+  -f state="$COMMIT_STATUS" \
   -f target_url="https://github.com/MetaMask/action-require-additional-reviewer"
 
 # The action should never fail, only set a status for the release branch HEAD

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -16,21 +16,21 @@ if [[ -z $GITHUB_REPOSITORY ]]; then
   exit 1
 fi
 
-HEAD_COMMIT_SHA=${1}
+HEAD_COMMIT_SHA=${2}
 
 if [[ -z $GITHUB_REPOSITORY ]]; then
   echo "Error: No head commit SHA specified."
   exit 1
 fi
 
-IS_RELEASE=${2}
+IS_RELEASE=${3}
 
 if [[ -z $IS_RELEASE ]]; then
   echo 'Error: No "is release" input specified.'
   exit 1
 fi
 
-NUM_OTHER_APPROVING_REVIEWERS=${3}
+NUM_OTHER_APPROVING_REVIEWERS=${4}
 
 if [[ $IS_RELEASE == "true" && -z $NUM_OTHER_APPROVING_REVIEWERS ]]; then
   echo "Error: No count of other approving reviewers specified."

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -58,12 +58,10 @@ fi
 gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT_SHA}" \
   -X "POST" \
   -H "Accept: application/vnd.github.v3+json" \
-  -f body='{
-    "context": "MetaMask/action-require-additional-reviewer",
-    "description": "'"$COMMIT_STATUS_DESCRIPTION"'",
-    "state": "'"$COMMIT_STATUS"'",
-    "target_url": "https://github.com/MetaMask/action-require-additional-reviewer"
-  }'
+  -f state="$COMMIT_STATUS" \
+  -f context="MetaMask/action-require-additional-reviewer" \
+  -f description="$COMMIT_STATUS_DESCRIPTION" \
+  -f target_url="https://github.com/MetaMask/action-require-additional-reviewer"
 
 # The action should never fail, only set a status for the release branch HEAD
 # commit.

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -23,14 +23,21 @@ if [[ -z $GITHUB_REPOSITORY ]]; then
   exit 1
 fi
 
-IS_RELEASE=${3}
+GITHUB_STATUS_NAME=${3}
+
+if [[ -z $GITHUB_STATUS_NAME ]]; then
+  echo 'Error: No GitHub status name specified.'
+  exit 1
+fi
+
+IS_RELEASE=${4}
 
 if [[ -z $IS_RELEASE ]]; then
   echo 'Error: No "is release" input specified.'
   exit 1
 fi
 
-NUM_OTHER_APPROVING_REVIEWERS=${4}
+NUM_OTHER_APPROVING_REVIEWERS=${5}
 
 if [[ $IS_RELEASE == "true" && -z $NUM_OTHER_APPROVING_REVIEWERS ]]; then
   echo "Error: No count of other approving reviewers specified."
@@ -58,10 +65,9 @@ fi
 gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT_SHA}" \
   -X "POST" \
   -H "Accept: application/vnd.github.v3+json" \
-  -f context="MetaMask/action-require-additional-reviewer" \
+  -f context="$GITHUB_STATUS_NAME" \
   -f description="$COMMIT_STATUS_DESCRIPTION" \
-  -f state="$COMMIT_STATUS" \
-  -f target_url="https://github.com/MetaMask/action-require-additional-reviewer"
+  -f state="$COMMIT_STATUS"
 
 # The action should never fail, only set a status for the release branch HEAD
 # commit.

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -58,7 +58,7 @@ fi
 gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT_SHA}" \
   -X "POST" \
   -H "Accept: application/vnd.github.v3+json" \
-  -d '{
+  -f body='{
     "context": "MetaMask/action-require-additional-reviewer",
     "description": "'"$COMMIT_STATUS_DESCRIPTION"'",
     "state": "'"$COMMIT_STATUS"'",

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -20,7 +20,7 @@ fi
 
 NUM_OTHER_APPROVING_REVIEWERS=${3}
 
-if [[ -z $NUM_OTHER_APPROVING_REVIEWERS ]]; then
+if [[ $IS_RELEASE == "true" && -z $NUM_OTHER_APPROVING_REVIEWERS ]]; then
   echo "Error: No count of other approving reviewers specified."
   exit 1
 fi


### PR DESCRIPTION
Using the success or failure of the action has drawbacks, and a status that is pending until it succeeds is more desirable. This PR implements exactly that behavior, using the GitHub Status API.

Since GitHub branch protection rules only apply to base branches, this new status will be created for every commit in every PR. Therefore, the status is set to success if the PR is not a release PR. For release PRs, the status is only set to success if the reviewer requirements are met, otherwise the status is set to pending.