### PR TITLE
Use github context sha value instead of event payload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/set-commit-status.sh \
           "${{ github.repository }}" \
-          "${{ github.event.pull_request.head.sha }}" \
+          "${{ github.sha }}" \
           "${{ inputs.github-status-name }}" \
           "${{ steps.check-branch-prefix.outputs.is-release }}" \
           "${{ steps.check-additional-reviewers.outputs.num-other-approving-reviewers }}"


### PR DESCRIPTION
The `pull_request` and `pull_request_review` payloads are not the same, as evidenced by this failed workflow run: https://github.com/MetaMask/action-require-additional-reviewer/pull/23/checks?check_run_id=3319671202