### PR TITLE
Improve fetching of workflow runs

### DIFF
--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -87,7 +87,13 @@ fi
 #
 # See the end of the file for details on the response value from GitHub.
 WORKFLOW_ID=$(
-  gh api "/repos/${GITHUB_REPOSITORY}/actions/runs" |
+  gh api "/repos/${GITHUB_REPOSITORY}/actions/runs" \
+    -X "GET" \
+    -H "Accept: application/vnd.github.v3+json" \
+    -f "branch=$PULL_REQUEST_BASE_BRANCH" \
+    -f "event=workflow_dispatch" \
+    -f "per_page=100" \
+    -f "status=success" |
   jq '.workflow_runs |
     map(select(
       .name == "'"${WORKFLOW_NAME}"'" and


### PR DESCRIPTION
Previously, we were fetching workflow runs in a very naive manner, grabbing all workflows for all events for all branches, regardless of status. This PR ensures that we only fetch successful workflow runs triggered `workflow_dispatch` on the repository base branch. If a release branch is really old, we can still fail to fetch the workflow that created it, but that should now be exceedingly rare.