### PR TITLE
Use access token with read:org scope to check for approving reviews

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -25,3 +25,5 @@ jobs:
       - uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          read-org-token: ${{ secrets.READ_ORG_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -14,13 +14,16 @@ inputs:
     description: 'The path to the directory where this action will look for its required artifacts.'
     default: 'gh-action__release-authors'
     required: true
+  github-status-name:
+    description: 'The string that will show up as the name of the GitHub status on PRs.'
+    default: 'Additional Reviews for Releases'
+    required: true
   release-branch-prefix:
     description: 'The prefix of release PR branch names for this repository.'
     default: 'release/'
     required: true
-  github-status-name:
-    description: 'The string that will show up as the name of the GitHub status on PRs.'
-    default: 'Additional Reviews for Releases'
+  read-org-token:
+    description: 'A GitHub access token with the "read:org" scope.'
     required: true
 
 runs:
@@ -52,8 +55,10 @@ runs:
       run: |
         if [[ "${{ steps.check-branch-prefix.outputs.is-release }}" == "true" ]]; then
           ${{ github.action_path }}/scripts/check-for-additional-reviewers.sh \
+            "${{ github.repository }}" \
             "${{ github.event.pull_request.number }}" \
-            "${{ inputs.artifacts-path }}"
+            "${{ inputs.artifacts-path }}" \
+            "${{ inputs.read-org-token }}"
         fi
 
     - name: Set Commit Status


### PR DESCRIPTION
Organization membership can be kept private by GitHub users. This PR adds an access token input that should have the `read:org` scope which is used for the call to check for approving reviews.