### PR TITLE
Fix documentation, remove redundant 'exit 0'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,32 @@ It is designed to be used with [`MetaMask/action-create-release-pr`](https://git
 
 ## Usage
 
-This action is designed to be used in conjunction with [`MetaMask/action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr).
+This action is designed to be used in conjunction with [`MetaMask/action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr), and will not work unless your repository also uses that action as recommended by its documentation.
 
-To use this action, you need to make a small addition to the `action-create-release-pr` workflow of your repository, and add a new workflow that uses this action:
+To use this action, you need to make a small addition to the `MetaMask/action-create-release-pr` workflow of your repository, and add a new workflow that uses this action:
 
 - [`.github/workflows/create-release-pr.yml`](https://github.com/MetaMask/action-require-additional-reviewer/blob/main/.github/workflows/create-release-pr.yml)
 - [`.github/workflows/require-additional-reviewer.yml`](https://github.com/MetaMask/action-require-additional-reviewer/blob/main/.github/workflows/require-additional-reviewer.yml)
   - **This workflow file self-references this action with the string "`/.`". Replace that string with "`MetaMask/action-require-additional-reviewer@v1`" in your workflow.**
 
-Once the Require Additional Reviewer workflow has run once, you can add it as a mandatory check in your repository branch protection settings.
+Once the Require Additional Reviewer workflow has run once, you it will create a GitHub commit status that you can use as a mandatory check in your repository branch protection settings.
 
-Note that, if you use this action, you **must not** rebase your release PRs before merging them back into the base branch.
-This action uses the commit hash of the base branch head to identify the workflow that created the release PR, in order to download the artifacts of that workflow.
-Merging the base branch into the release branch is fine.
+This action should never fail, and the status check it creates should only be either pending or successful. If the action fails to execute, first try recreating the release PR. If that doesn't work, identify the error produced by the workflow run and file a bug report.
+
+### Access Token
+
+Under recommended usage, the only input you have to provide to this action is an access token with the `read:org` scope. This token is necessary in order to determine the organization assocation of reviewers.
+See the GitHub documentation for how to [create access tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) and how to [use them in workflows](https://docs.github.com/en/actions/reference/encrypted-secrets).
+
+### Constraints on Relase Pull Requests
+
+Due to constraints imposed by the GitHub Actions platform and the GitHub API, this action imposes some constraints on release pull requests. Therefore, if you use this action, your release pull requests:
+
+- **must not** be rebased before being merged into the base branch.
+  - This action uses the commit hash of the original base branch head to identify the workflow that created the release PR, in order to download the artifacts of that workflow.
+  - Merging the base branch into the PR branch is fine.
+- **should not** be left open for extended periods of time.
+  - If your repository has a lot of `workflow_dispatch` events and a release PR is left open for a long time, there's a chance that this action will fail to extract the ID of the workflow that created the release branch. This action only searches the first 100 successful `workflow_dispatch` events targeting the PR base branch for the workflow run that created the release PR.
 
 ## Contributing
 

--- a/scripts/check-for-additional-reviewers.sh
+++ b/scripts/check-for-additional-reviewers.sh
@@ -98,12 +98,13 @@ NUM_OTHER_APPROVING_REVIEWERS=$(
 
 echo ::set-output name=num-other-approving-reviewers::"$NUM_OTHER_APPROVING_REVIEWERS"
 
-# Relevant GitHub documentation:
+# API endpoint documentation
+# https://docs.github.com/en/rest/reference/pulls#reviews
+
+# Relevant enums
 # https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate
 # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
 
-# https://docs.github.com/en/rest/reference/pulls#reviews
-#
 # gh api /repos/{owner}/{repo}/pulls/{pull_number}/reviews \
 #
 # {

--- a/scripts/check-for-additional-reviewers.sh
+++ b/scripts/check-for-additional-reviewers.sh
@@ -69,6 +69,8 @@ echo \
 
 # Get the JSON data from GitHub. For the expected format of this data, see the
 # end of this file.
+# We pass the READ_ORG_TOKEN in the authorization header, or else we cannot see
+# hidden organization memberships.
 PR_INFO=$(
   gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
     -X "GET" \
@@ -100,30 +102,26 @@ echo ::set-output name=num-other-approving-reviewers::"$NUM_OTHER_APPROVING_REVI
 # https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate
 # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
 
-# Related, but not exactly the same as "gh pr view":
-# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+# https://docs.github.com/en/rest/reference/pulls#reviews
 #
-# https://cli.github.com/manual/gh_pr_view
-#
-# gh pr view --json number,reviews
+# gh api /repos/{owner}/{repo}/pulls/{pull_number}/reviews \
 #
 # {
-#   "number": 99,
-#   "reviews": [
+#   [
 #     {
-#       "author": {
+#       "user": {
 #         "login": "username1"
 #       },
 #       "state": "COMMENTED",
-#       "authorAssociation": "OWNER",
+#       "author_association": "OWNER",
 #       ...
 #     },
 #     {
-#       "author": {
+#       "user": {
 #         "login": "username2"
 #       },
 #       "state": "APPROVED",
-#       "authorAssociation": "MEMBER",
+#       "author_association": "MEMBER",
 #       ...
 #     },
 #     ...

--- a/scripts/check-is-release.sh
+++ b/scripts/check-is-release.sh
@@ -4,6 +4,9 @@ set -x
 set -e
 set -o pipefail
 
+# This script checks the prefix of the PR branch name to determine whether it is
+# a release PR.
+
 HEAD_BRANCH_NAME=${1}
 
 if [[ -z $HEAD_BRANCH_NAME ]]; then

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -114,7 +114,7 @@ mkdir -p "$ARTIFACTS_DIR_PATH" && cd "$ARTIFACTS_DIR_PATH"
 gh run download "$WORKFLOW_ID" -n "$ARTIFACT_NAME"
 echo "Artifact successfully downloaded!"
 
-# gh api /repos/ORG_NAME/REPO_NAME/actions/runs
+# gh api /repos/{org}/{repo}/actions/runs
 # 
 # https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
 # https://docs.github.com/en/graphql/reference/objects#workflowrun

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -114,13 +114,14 @@ mkdir -p "$ARTIFACTS_DIR_PATH" && cd "$ARTIFACTS_DIR_PATH"
 gh run download "$WORKFLOW_ID" -n "$ARTIFACT_NAME"
 echo "Artifact successfully downloaded!"
 
-# gh api /repos/{org}/{repo}/actions/runs
-# 
 # https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
+
 # https://docs.github.com/en/graphql/reference/objects#workflowrun
 # https://docs.github.com/en/graphql/reference/objects#checkrun
 # https://docs.github.com/en/graphql/reference/enums#checkconclusionstate
 #
+# gh api /repos/{org}/{repo}/actions/runs
+# 
 # [
 #  {
 #    "id": 1118040733,

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -114,12 +114,13 @@ mkdir -p "$ARTIFACTS_DIR_PATH" && cd "$ARTIFACTS_DIR_PATH"
 gh run download "$WORKFLOW_ID" -n "$ARTIFACT_NAME"
 echo "Artifact successfully downloaded!"
 
+# API endpoint documentation
 # https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
-#
-# https://docs.github.com/en/graphql/reference/objects#workflowrun
+
+# Relevant objects and enums
 # https://docs.github.com/en/graphql/reference/objects#checkrun
 # https://docs.github.com/en/graphql/reference/enums#checkconclusionstate
-#
+
 # gh api /repos/{org}/{repo}/actions/runs
 # 
 # [

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -115,7 +115,7 @@ gh run download "$WORKFLOW_ID" -n "$ARTIFACT_NAME"
 echo "Artifact successfully downloaded!"
 
 # https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
-
+#
 # https://docs.github.com/en/graphql/reference/objects#workflowrun
 # https://docs.github.com/en/graphql/reference/objects#checkrun
 # https://docs.github.com/en/graphql/reference/enums#checkconclusionstate

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 set -o pipefail
 
-# This PR checks whether the current PR meets the additional reviewer
+# This script checks whether the current PR meets the additional reviewer
 # requirement for release PRs. Non-release PRs succeed by default.
 # It uses the GitHub Status API to accomplish this. See the actual API call
 # at the end of the file for more details.
@@ -71,4 +71,3 @@ gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT
 
 # The action should never fail, only set a status for the release branch HEAD
 # commit.
-exit 0


### PR DESCRIPTION
This PR updates the readme and inline documentation to match what we shipped as `v1` of this action. It also removes a redundant call to `exit 0`.