### PR TITLE
Rename read:org token secret to match GitHub settings

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          read-org-token: ${{ secrets.READ_ORG_TOKEN }}
+          read-org-token: ${{ secrets.ORG_READER }}


### PR DESCRIPTION
This PR renames the `read:org` secret in the workflow for this action to `ORG_READER`, since that's what we named the corresponding organization-level secret.