### PR TITLE
Echo an empty string if grep fails in subshell

### DIFF
--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -59,7 +59,7 @@ fi
 
 OLDEST_PR_BRANCH_MERGE_COMMIT=$(
   git rev-list "$PREFIXED_PULL_REQUEST_BASE_BRANCH"..HEAD --merges --reverse |
-  grep -o -m 1 '\w\+'
+  grep -o -m 1 '\w\+' || echo ''
 )
 
 if [[ -n $OLDEST_PR_BRANCH_MERGE_COMMIT ]]; then


### PR DESCRIPTION
This PR ensures that a subshell whose final command is `grep` always exits with a `0` code, preventing the entire action from blowing up.

I had already made this change in one place, but forgotten this instance.