### PR TITLE
Fix automatic shorthand major version tag updating

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # This is to guarantee that the most recent tag is fetched,
+          # which we need for updating the shorthand major version tag.
+          fetch-depth: 0
           # We check out the release pull request's base branch, which will be
           # used as the base branch for all git operations.
           ref: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
This PR fixes shorthand major version tag updating by setting the `fetch-depth` of `actions/checkout` to `0` in the `publish-release` workflow. This is only required for our actions.