### PR TITLE
Fix action always failing for PRs from forks

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -19,9 +19,9 @@ jobs:
           # need to find the earliest common ancestor commit of the base and
           # release branches.
           fetch-depth: 0
-          # We want the head / feature branch to be checked out, and we will
-          # compare it to the base branch in the action.
-          ref: ${{ github.event.pull_request.head.ref }}
+          # We want the head commit of the feature branch to be checked out,
+          # and we will compare it to the base branch in the action.
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -50,7 +50,11 @@ COMMIT_STATUS_DESCRIPTION="Whether this PR meets the additional reviewer require
 
 if [[ "$IS_RELEASE" == "false" ]]; then
   echo "The PR is not a release PR. Setting status to success by default."
-  COMMIT_STATUS="success"
+  # Non-Release PRs might be opened by a community contributor using a fork,
+  # which cannot set a commit status due to lack of write permissions
+  # (see https://github.community/t/github-actions-are-severely-limited-on-prs/18179)
+  # Exiting will set the status to "success" anyway.
+  exit 0
 elif (( NUM_OTHER_APPROVING_REVIEWERS > 0 )); then
   echo "Success! Found approving reviews from organization members."
   COMMIT_STATUS="success"
@@ -61,6 +65,8 @@ fi
 
 # https://cli.github.com/manual/gh_api
 # https://docs.github.com/en/rest/reference/repos#create-a-commit-status
+# Warning! Setting commit status fails if the pull request was opened from a fork
+# See https://github.community/t/github-actions-are-severely-limited-on-prs/18179
 
 gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT_SHA}" \
   -X "POST" \


### PR DESCRIPTION
Use `exit 0` instead of manually writing GitHub status to "success"
when a PR is not a release PR. This means that this action will
now be successful for all non-release PRs, including those from forks.

Explanation:
------------

GitHub actions are severely limited on PRs from forks (which is what community contributors like me use)
(see https://github.community/t/github-actions-are-severely-limited-on-prs/18179)

This is because the `GITHUB_TOKEN` only ever has read-only permissions for security purposes when running from a fork, which means that the `set-commit-status.sh` script cannot set the commit status to "success" using the GitHub API.

However, by default, GitHub actions will automatically set the status to "success" anyway, if the action finishes without any errors, so we can just change the script to `exit 0` in this case.

### Example Error when I made a PR from a fork

> ```console
> # ... [lines removed by me]
> + [[ -z e24f8ccc6b5251db49284d33ed67c5c84f002dce ]]
> The PR is not a release PR. Setting status to success by default.
> + COMMIT_STATUS_DESCRIPTION='Whether this PR meets the additional reviewer requirement for releases.'
> + [[ false == \f\a\l\s\e ]]
> + echo 'The PR is not a release PR. Setting status to success by default.'
> + COMMIT_STATUS=success
> + gh api https://api.github.com/repos/MetaMask/eth-trezor-keyring/statuses/e24f8ccc6b5251db49284d33ed67c5c84f002dce -X POST -H 'Accept: application/vnd.github.v3+json' -f 'context=Additional Reviews for Releases' -f 'description=Whether this PR meets the additional reviewer requirement for releases.' -f state=success
> gh: Resource not accessible by integration (HTTP 403)
> {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/repos#create-a-commit-status"}
> ```
>
> Source: https://github.com/MetaMask/eth-trezor-keyring/runs/4267049794?check_suite_focus=true

Bug encountered when I was trying to make a PR to: https://github.com/MetaMask/eth-trezor-keyring/pull/106#issuecomment-974544776