### PR TITLE
Revert #37

### DIFF
--- a/.github/workflows/require-additional-reviewer.yml
+++ b/.github/workflows/require-additional-reviewer.yml
@@ -19,9 +19,9 @@ jobs:
           # need to find the earliest common ancestor commit of the base and
           # release branches.
           fetch-depth: 0
-          # We want the head commit of the feature branch to be checked out,
-          # and we will compare it to the base branch in the action.
-          ref: ${{ github.event.pull_request.head.sha }}
+          # We want the head / feature branch to be checked out, and we will
+          # compare it to the base branch in the action.
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/set-commit-status.sh
+++ b/scripts/set-commit-status.sh
@@ -50,11 +50,7 @@ COMMIT_STATUS_DESCRIPTION="Whether this PR meets the additional reviewer require
 
 if [[ "$IS_RELEASE" == "false" ]]; then
   echo "The PR is not a release PR. Setting status to success by default."
-  # Non-Release PRs might be opened by a community contributor using a fork,
-  # which cannot set a commit status due to lack of write permissions
-  # (see https://github.community/t/github-actions-are-severely-limited-on-prs/18179)
-  # Exiting will set the status to "success" anyway.
-  exit 0
+  COMMIT_STATUS="success"
 elif (( NUM_OTHER_APPROVING_REVIEWERS > 0 )); then
   echo "Success! Found approving reviews from organization members."
   COMMIT_STATUS="success"
@@ -65,8 +61,6 @@ fi
 
 # https://cli.github.com/manual/gh_api
 # https://docs.github.com/en/rest/reference/repos#create-a-commit-status
-# Warning! Setting commit status fails if the pull request was opened from a fork
-# See https://github.community/t/github-actions-are-severely-limited-on-prs/18179
 
 gh api "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_COMMIT_SHA}" \
   -X "POST" \


### PR DESCRIPTION
This reverts #37. An important claim about the implementation turned out to be false; exiting with 0 instead of explicitly setting the status check does not turn the check into a success.

It's possible to make this PR compatible with PRs from forks, but it will require using the `pull_request_target` event trigger, which adds [a slew of security concerns](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).